### PR TITLE
fix for broadcast fast blocks

### DIFF
--- a/src/core/database/blocks.cr
+++ b/src/core/database/blocks.cr
@@ -169,6 +169,11 @@ module ::Axentro::Core::Data::Blocks
     @db.query_one("select count(*) from blocks", as: Int32)
   end
 
+  def do_i_have_block(index : Int64) : Bool
+    result = @db.query_one("select count(*) from blocks where idx = ? limit 1", index, as: Int64)
+    result > 0_i64
+  end
+
   # ------- Delete -------
   def delete_block(from : Int64)
     @db.exec "delete from blocks where idx = ?", from


### PR DESCRIPTION
The node received a fast block and decided it was invalid for some reason and then tried to re-sync the chain with invalid indexes.

Implemented simple approach for processing incoming fast block for phase 1 - more complex syncing rules can be added when required.
