### PR TITLE
log unexpected errors on transaction validation

### DIFF
--- a/src/common/axentro_exception.cr
+++ b/src/common/axentro_exception.cr
@@ -10,7 +10,7 @@
 #
 # Removal or modification of this copyright notice is prohibited.
 
-module ::Axentro::Core
+module ::Axentro::Common
   class AxentroException < Exception
   end
 end

--- a/src/common/modules.cr
+++ b/src/common/modules.cr
@@ -9,5 +9,5 @@
 # LICENSE file.
 #
 # Removal or modification of this copyright notice is prohibited.
-
+require "./axentro_exception"
 require "./modules/*"

--- a/src/common/modules/validator.cr
+++ b/src/common/modules/validator.cr
@@ -13,7 +13,7 @@
 module ::Axentro::Common::Validator
   def valid_amount?(amount : Int64) : Bool
     if Int64::MAX < amount || 0 > amount
-      raise "the amount is out of range"
+      raise AxentroException.new("the amount is out of range")
     end
 
     true
@@ -23,7 +23,7 @@ module ::Axentro::Common::Validator
     amount_decimal = BigDecimal.new(amount)
 
     if BigDecimal.new(Int64::MAX, Denomination::SCALE_DECIMAL) < amount_decimal || 0 > amount_decimal
-      raise message + "the amount is out of range"
+      raise AxentroException.new(message + "the amount is out of range")
     end
 
     true

--- a/src/core/axentro_exception.cr
+++ b/src/core/axentro_exception.cr
@@ -1,0 +1,16 @@
+# Copyright © 2017-2020 The Axentro Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the Axentro Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+module ::Axentro::Core
+  class AxentroException < Exception
+  end
+end

--- a/src/core/blockchain/transaction.cr
+++ b/src/core/blockchain/transaction.cr
@@ -47,19 +47,19 @@ module ::Axentro::Core
     def validate_common(transactions : Array(Core::Transaction), network_type : String) : ValidatedTransactions
       vt = ValidatedTransactions.empty
       transactions.each do |transaction|
-        raise "length of transaction id has to be 64: #{transaction.id}" if transaction.id.size != 64
-        raise "message size exceeds: #{transaction.message.bytesize} for #{MESSAGE_SIZE_LIMIT}" if transaction.message.bytesize > MESSAGE_SIZE_LIMIT
-        raise "token size exceeds: #{transaction.token.bytesize} for #{TOKEN_SIZE_LIMIT}" if transaction.token.bytesize > TOKEN_SIZE_LIMIT
-        raise "unscaled transaction" if transaction.scaled != 1
+        raise AxentroException.new("length of transaction id has to be 64: #{transaction.id}") if transaction.id.size != 64
+        raise AxentroException.new("message size exceeds: #{transaction.message.bytesize} for #{MESSAGE_SIZE_LIMIT}") if transaction.message.bytesize > MESSAGE_SIZE_LIMIT
+        raise AxentroException.new("token size exceeds: #{transaction.token.bytesize} for #{TOKEN_SIZE_LIMIT}") if transaction.token.bytesize > TOKEN_SIZE_LIMIT
+        raise AxentroException.new("unscaled transaction") if transaction.scaled != 1
 
         transaction.senders.each do |sender|
           network = Keys::Address.from(sender[:address], "sender").network
-          raise "sender address: #{sender[:address]} has wrong network type: #{network[:name]}, this node is running as: #{network_type}" if network[:name] != network_type
+          raise AxentroException.new("sender address: #{sender[:address]} has wrong network type: #{network[:name]}, this node is running as: #{network_type}") if network[:name] != network_type
 
           public_key = Keys::PublicKey.new(sender[:public_key], network)
 
           if public_key.address.as_hex != sender[:address]
-            raise "sender public key mismatch - sender public key: #{public_key.as_hex} is not for sender address: #{sender[:address]}"
+            raise AxentroException.new("sender public key mismatch - sender public key: #{public_key.as_hex} is not for sender address: #{sender[:address]}")
           end
 
           verbose "unsigned_json: #{transaction.as_unsigned.to_json}"
@@ -72,11 +72,11 @@ module ::Axentro::Core
           verbose "verify signature result: #{verify_result}"
 
           if !verify_result
-            raise "invalid signing for sender: #{sender[:address]}"
+            raise AxentroException.new("invalid signing for sender: #{sender[:address]}")
           end
 
           unless Keys::Address.from(sender[:address], "sender")
-            raise "invalid checksum for sender's address: #{sender[:address]}"
+            raise AxentroException.new("invalid checksum for sender's address: #{sender[:address]}")
           end
 
           valid_amount?(sender[:amount])
@@ -85,19 +85,22 @@ module ::Axentro::Core
         transaction.recipients.each do |recipient|
           recipient_address = Keys::Address.from(recipient[:address], "recipient")
           unless recipient_address
-            raise "invalid checksum for recipient's address: #{recipient[:address]}"
+            raise AxentroException.new("invalid checksum for recipient's address: #{recipient[:address]}")
           end
 
           network = recipient_address.network
-          raise "recipient address: #{recipient[:address]} has wrong network type: #{network[:name]}, this node is running as: #{network_type}" if network[:name] != network_type
+          raise AxentroException.new("recipient address: #{recipient[:address]} has wrong network type: #{network[:name]}, this node is running as: #{network_type}") if network[:name] != network_type
 
           valid_amount?(recipient[:amount])
         end
 
         transaction = transaction.set_common_validated
         vt << transaction.as_validated
-      rescue e : Exception
+      rescue e : AxentroException
         vt << FailedTransaction.new(transaction, e.message || "unknown error", "validate_common").as_validated
+      rescue e : Exception
+        vt << FailedTransaction.new(transaction, "unepected error", "validate_common").as_validated
+        error("#{e.class}: #{e.message || "unknown error"}\n#{e.backtrace.join("\n")}")
       end
       vt
     end

--- a/src/core/keys/address.cr
+++ b/src/core/keys/address.cr
@@ -18,7 +18,7 @@ module ::Axentro::Core::Keys
 
     def initialize(hex_address : String, @network : Core::Node::Network = MAINNET, name : String = "generic")
       @hex = hex_address
-      raise "invalid #{name} address checksum for: #{@hex}" unless is_valid?
+      raise AxentroException.new("invalid #{name} address checksum for: #{@hex}") unless is_valid?
     end
 
     def as_hex : String
@@ -46,7 +46,11 @@ module ::Axentro::Core::Keys
     end
 
     def self.get_network_from_address(hex_address) : Core::Node::Network
-      decoded_address = Base64.decode_string(hex_address)
+      begin
+        decoded_address = Base64.decode_string(hex_address)
+      rescue Base64::Error
+        raise AxentroException.new("invalid address")
+      end
 
       case decoded_address[0..1]
       when MAINNET[:prefix]
@@ -54,7 +58,7 @@ module ::Axentro::Core::Keys
       when TESTNET[:prefix]
         TESTNET
       else
-        raise "invalid network: #{decoded_address[0..1]} for address: #{hex_address}"
+        raise AxentroException.new("invalid network: #{decoded_address[0..1]} for address: #{hex_address}")
       end
     end
 

--- a/src/core/keys/address.cr
+++ b/src/core/keys/address.cr
@@ -18,7 +18,7 @@ module ::Axentro::Core::Keys
 
     def initialize(hex_address : String, @network : Core::Node::Network = MAINNET, name : String = "generic")
       @hex = hex_address
-      raise AxentroException.new("invalid #{name} address checksum for: #{@hex}") unless is_valid?
+      raise Axentro::Common::AxentroException.new("invalid #{name} address checksum for: #{@hex}") unless is_valid?
     end
 
     def as_hex : String
@@ -49,7 +49,7 @@ module ::Axentro::Core::Keys
       begin
         decoded_address = Base64.decode_string(hex_address)
       rescue Base64::Error
-        raise AxentroException.new("invalid address")
+        raise Axentro::Common::AxentroException.new("invalid address")
       end
 
       case decoded_address[0..1]
@@ -58,7 +58,7 @@ module ::Axentro::Core::Keys
       when TESTNET[:prefix]
         TESTNET
       else
-        raise AxentroException.new("invalid network: #{decoded_address[0..1]} for address: #{hex_address}")
+        raise Axentro::Common::AxentroException.new("invalid network: #{decoded_address[0..1]} for address: #{hex_address}")
       end
     end
 

--- a/src/core/keys/key_utils.cr
+++ b/src/core/keys/key_utils.cr
@@ -18,6 +18,8 @@ module ::Axentro::Core::Keys
       public_key = Crypto::Ed25519PublicSigningKey.new(hex_public_key)
       signature = Crypto::Ed25519Signature.new(signature_hex)
       signature.check(message, public: public_key)
+    rescue e : Exception
+      raise AxentroException.new("Verify fail: #{e.message}")
     end
 
     def self.sign(hex_private_key, message) : String

--- a/src/core/keys/key_utils.cr
+++ b/src/core/keys/key_utils.cr
@@ -19,7 +19,7 @@ module ::Axentro::Core::Keys
       signature = Crypto::Ed25519Signature.new(signature_hex)
       signature.check(message, public: public_key)
     rescue e : Exception
-      raise AxentroException.new("Verify fail: #{e.message}")
+      raise Axentro::Common::AxentroException.new("Verify fail: #{e.message}")
     end
 
     def self.sign(hex_private_key, message) : String


### PR DESCRIPTION
Replace basic raise <string> (on #validate_common) by a custom exception in order to differentiate between managed and unexpected errors
