### PR TITLE
fix trim chain in memory to not trim out fast blocks

### DIFF
--- a/spec/units/blockchain/blockchain.cr
+++ b/spec/units/blockchain/blockchain.cr
@@ -76,6 +76,34 @@ describe Blockchain do
     end
   end
 
+  describe "trim chain" do
+    # These tests use >= in the assertion because it has a timestamp cutoff which can vary when the test runs
+    it "should trim the chain correctly taking into account both slow and fast blocks when there are fewer fast blocks" do
+      with_factory do |block_factory|
+        # trim_chain_in_memory - should always keep both @slow_blocks_to_hold and @fast_blocks_to_hold in the memory chain
+        block_factory.add_fast_blocks(2).add_slow_blocks(block_factory.slow_blocks_to_hold + 10)
+        block_factory.chain.count(&.is_fast_block?).should eq(2)
+        block_factory.chain.count(&.is_slow_block?).should be >= 60
+      end
+    end
+    it "should trim the chain correctly taking into account both slow and fast blocks when there are more fast blocks" do
+      with_factory do |block_factory|
+        # trim_chain_in_memory - should always keep both @slow_blocks_to_hold and @fast_blocks_to_hold in the memory chain
+        block_factory.add_fast_blocks(block_factory.fast_blocks_to_hold + 10).add_slow_blocks(block_factory.slow_blocks_to_hold + 10)
+        block_factory.chain.count(&.is_fast_block?).should eq(60)
+        block_factory.chain.count(&.is_slow_block?).should be >= 60
+      end
+    end
+    it "should trim the chain correctly taking into account both slow and fast blocks when there are more fast blocks than slow" do
+      with_factory do |block_factory|
+        # trim_chain_in_memory - should always keep both @slow_blocks_to_hold and @fast_blocks_to_hold in the memory chain
+        block_factory.add_slow_blocks(1).add_fast_blocks(block_factory.fast_blocks_to_hold + 10)
+        block_factory.chain.count(&.is_fast_block?).should be >= 60
+        block_factory.chain.count(&.is_slow_block?).should eq(2)
+      end
+    end
+  end
+
   describe "add_transaction" do
     it "should add a transaction to the pool" do
       with_factory do |block_factory, transaction_factory|
@@ -300,13 +328,14 @@ describe Blockchain do
     end
     it "should load a subset of the whole chain from the database when the chain size is more than the memory allocation" do
       with_factory do |block_factory|
-        blocks_to_add = block_factory.blocks_to_hold + 8
-        block_factory.add_slow_blocks(blocks_to_add)
+        slow_blocks_to_add = block_factory.slow_blocks_to_hold + 8
+        fast_blocks_to_add = slow_blocks_to_add
+        block_factory.add_slow_blocks(slow_blocks_to_add).add_fast_blocks(fast_blocks_to_add)
         database = block_factory.database
         blockchain = Blockchain.new("testnet", block_factory.node_wallet, "", database, nil, nil, 20, 100, false, 512, true)
         blockchain.setup(block_factory.node)
         # including genesis block total chain size should be the number of blocks to hold
-        blockchain.chain.size.should eq(blockchain.blocks_to_hold)
+        blockchain.chain.size.should eq(blockchain.slow_blocks_to_hold + blockchain.fast_blocks_to_hold)
       end
     end
   end

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -102,11 +102,12 @@ describe RESTController do
     end
     it "should return the full blockchain size when chain is bigger than memory" do
       with_factory do |block_factory, _|
-        blocks_to_add = block_factory.blocks_to_hold + 8
-        block_factory.add_slow_blocks(blocks_to_add)
+        slow_blocks_to_add = block_factory.slow_blocks_to_hold + 8
+        fast_blocks_to_add = slow_blocks_to_add
+        block_factory.add_slow_blocks(slow_blocks_to_add).add_fast_blocks(fast_blocks_to_add)
         exec_rest_api(block_factory.rest.__v1_blockchain_size(context("/api/v1/blockchain/size"), no_params)) do |result|
           result["status"].to_s.should eq("success")
-          result["result"]["totals"]["total_size"].should eq(blocks_to_add + 1)
+          result["result"]["totals"]["total_size"].should eq(slow_blocks_to_add + fast_blocks_to_add + 1)
         end
       end
     end

--- a/spec/utils/chain_generator.cr
+++ b/spec/utils/chain_generator.cr
@@ -82,8 +82,12 @@ module ::Units::Utils::ChainGenerator
       enable_difficulty
     end
 
-    def blocks_to_hold
-      @blockchain.blocks_to_hold
+    def slow_blocks_to_hold
+      @blockchain.slow_blocks_to_hold
+    end
+
+    def fast_blocks_to_hold
+      @blockchain.fast_blocks_to_hold
     end
 
     def add_slow_block(with_refresh : Bool = true)


### PR DESCRIPTION
The in memory trim was trimming out fast blocks based on the cutoff time of the first slow block. 
Fixed it to trim fast and slow separately and keep both in the chain